### PR TITLE
mido: sepolicy: Address system_app denial

### DIFF
--- a/sepolicy/vendor/system_app.te
+++ b/sepolicy/vendor/system_app.te
@@ -1,0 +1,2 @@
+#============= system_app ==============
+allow system_app sysfs:file { getattr open read write };


### PR DESCRIPTION
This fixes denial for:-

12-28 23:01:06.890 I/settings.device(20697): type=1400 audit(0.0:93890): avc: denied { read } for name="vtg_level" dev="sysfs" ino=30564 scontext=u:r:system_app:s0 tcontext=u:object_r:sysfs:s0 tclass=file permissive=1

12-28 23:01:06.890 I/settings.device(20697): type=1400 audit(0.0:93891): avc: denied { open } for path="/sys/devices/virtual/timed_output/vibrator/vtg_level" dev="sysfs" ino=30564 scontext=u:r:system_app:s0 tcontext=u:object_r:sysfs:s0 tclass=file permissive=1

12-28 23:01:06.890 I/settings.device(20697): type=1400 audit(0.0:93892): avc: denied { getattr } for path="/sys/devices/virtual/timed_output/vibrator/vtg_level" dev="sysfs" ino=30564 scontext=u:r:system_app:s0 tcontext=u:object_r:sysfs:s0 tclass=file permissive=1

12-28 23:01:07.800 I/settings.device(20697): type=1400 audit(0.0:93893): avc: denied { write } for name="vtg_level" dev="sysfs" ino=30564 scontext=u:r:system_app:s0 tcontext=u:object_r:sysfs:s0 tclass=file permissive=1